### PR TITLE
bump reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ A simple JWT validator for Microsoft Azure Id tokens.
 
 [dependencies]
 jsonwebtoken = { version = "7.2.0", default-features = false }
-reqwest = {version = "0.11.1", default-features = false, features = ["blocking", "json", "rustls-tls"]}
+reqwest = {version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"]}
 serde = { version = "1.0.124", features = ["derive"] }
 chrono = "0.4.19"
 


### PR DESCRIPTION
This bumps reqwest to 0.12. Reqwest 0.12 uses http 1.0 which I need to be able to bump my other dependencies like axum and so on