### PR TITLE
Rewrite to be async-capable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_jwt"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Carl Fredrik Samson <cf@samson.no>"]
 edition = "2018"
 repository = "https://github.com/cfsamson/azure-jwt"
@@ -13,9 +13,14 @@ description = """
 A simple JWT validator for Microsoft Azure Id tokens.
 """
 
+[features]
+default = ["async"]
+blocking = ["reqwest/blocking"]
+async = ["dep:reqwest"]
+
 [dependencies]
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
-reqwest = {version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"]}
+reqwest = {version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true}
 serde = { version = "1", features = ["derive"] }
 chrono = "0.4"
 
@@ -26,3 +31,7 @@ base64 = "0.22.0"
 [[bench]]
 name = "validation"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,27 @@
 use crate::jwt;
 use std::{error::Error, fmt};
 
+// non_exhaustive:
+// Allows ConnectionError variant to be conditional.
+// Also allows variants to be added for control-flow reasons.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AuthErr {
+    /// The auth is in an invalid state. For example, it might have attempted offline-validation
+    /// without having set the public keys.
+    InvalidState,
+    /// The token is not valid in our context. For example, it might be missing a key-id.
+    InvalidTokenState,
+    /// The token did not match our expected values. For example, it might have provided a key-id
+    /// that did not match any of the public keys. This may indicate public-keys should be
+    /// refreshed, otherwise it indicates an invalid token.
+    TokenMismatch,
     InvalidToken(jwt::errors::Error),
+    /// # Optional
+    ///
+    /// This requires the optional `async` or `blocking` feature to be enabled.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "async", feature = "blocking"))))]
+    #[cfg(any(feature = "async", feature = "blocking"))]
     ConnectionError(reqwest::Error),
     Other(String),
     ParseError(String),
@@ -16,7 +34,11 @@ impl fmt::Display for AuthErr {
         use AuthErr::*;
 
         match self {
+            InvalidState => write!(f, "No public keys found"),
+            InvalidTokenState => write!(f, "No `kid` in token"),
+            TokenMismatch => write!(f, "No public keys matched `kid` from token"),
             InvalidToken(err) => write!(f, "Invalid token. {err}"),
+            #[cfg(any(feature = "async", feature = "blocking"))]
             ConnectionError(err) => write!(f, "Could not connect to Microsoft. {err}"),
             Other(msg) => write!(f, "An error occurred: {msg}"),
             ParseError(msg) => write!(f, "Could not parse token. {msg}"),
@@ -24,6 +46,7 @@ impl fmt::Display for AuthErr {
     }
 }
 
+#[cfg(any(feature = "async", feature = "blocking"))]
 impl From<reqwest::Error> for AuthErr {
     fn from(e: reqwest::Error) -> AuthErr {
         AuthErr::ConnectionError(e)


### PR DESCRIPTION
This is mainly a rewrite of the logic, with an attempt to keep the API to the documented contract.

## API changes:

* Renamed `refresh_rwks_uri` to `refresh_jwks_uri`.
* All calls that can trigger web requests are now only provided when a feature is used. By default, `async` is enabled, because reqwest shares the same behavior. The feature `blocking` will enable the previous API calls with the same/similar behaviors.
* Async API are all named similarly, but with an `_async` postfix.
* `is_keys_valid` renamed to `has_valid_keys`, mainly due to the singular form of a plural name being awkward.
* `set_no_retry` removed; this behavior is now used implicitly by the caller of validation.
* Explicitly offline-validation functions are provided, which inherently cannot retry. Online validation inherently will retry when the criteria are met. Similarly there is now no special behavior in the validation based on the original `new_offline` call (internally `is_offline` is removed and now implicit at validation), but it's still useful for dictating when the rest of the web-based initialization occurs.
* New `AuthError` enum variants, including `non_exhaustive` tag.
* Uses of `T: Serialize + Deserialize` were relaxed to `T: DeserializeOwned`, exactly mirroring the API provided by `jwt`.

## Behavioral changes:

* `AzureAuth::new` will now fetch keys in addition to the `jwks_uri`, as documented.
* Validation retry logic simplified, can no longer trigger a panic, and no longer uses recursion. A retry can *only* occur when the `kid` is not found, and the keys are stale for at least an hour. The retry will only refresh the keys and attempt validation *once* more.
* Reqwest is now optional, and will not be included in the dependencies when neither `async` nor `blocking` are enabled.
* `set_public_keys` treats an empty-vec as clearing.

## Internal adjustments

Both of these were intended to promote code-reuse and help make functions easier to reason about:

* Cases of branching logic are flattened and simplified.
* Validation call hierarchy simplified to go through validate_custom_offline.

## TL;DR:

* Minor API adjustments that should have obvious migrations.
* Behavior changes to better match a caller's expectations.
* Blocking API still available with the same names under `blocking` feature.
* Async API now available under `async` feature, duplicating all the blocking API but with `_async` in the names.

## Legal

This work was performed as a normal part of my employment. My employing company (Velocity A Managed Solutions Company) has authorized me to release it matching the license (MIT) of the upstream repository, and submit it as a PR.
